### PR TITLE
Add S3 dashboard docs and base path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ results/
     ├── metrics.json                     # Performance metrics in JSON format
     └── valkey_log_cluster_disabled.log  # Valkey server logs
 ```
+
+## Dashboard Hosted on S3
+
+The `dashboard/` directory contains a small React application for visualizing
+benchmark metrics. Changes to this directory trigger the `dashboard_sync.yml`
+workflow which uploads the files to an Amazon S3 bucket configured for static
+website hosting. Metrics files (`completed_commits.json` and the `results/`
+folder) are stored in the same bucket so the dashboard can fetch them directly.
+
+If your metrics reside under a prefix, supply that prefix via the `base` query
+parameter when opening the dashboard:
+
+```
+https://<bucket-url>/dashboard/index.html?base=path/to/prefix
+```
+
+See `dashboard/README.md` for more details.
 ## License
 
 This project is licensed under the same license as Valkey.

--- a/README.md
+++ b/README.md
@@ -126,14 +126,8 @@ workflow which uploads the files to an Amazon S3 bucket configured for static
 website hosting. Metrics files (`completed_commits.json` and the `results/`
 folder) are stored in the same bucket so the dashboard can fetch them directly.
 
-If your metrics reside under a prefix, supply that prefix via the `base` query
-parameter when opening the dashboard:
-
-```
-https://<bucket-url>/dashboard/index.html?base=path/to/prefix
-```
-
-See `dashboard/README.md` for more details.
+Open `dashboard/index.html` from your bucket to view the latest benchmark
+results. See `dashboard/README.md` for more details.
 ## License
 
 This project is licensed under the same license as Valkey.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,12 +5,3 @@ This folder contains a lightweight React-based dashboard used to visualize bench
 The static files are uploaded to an Amazon S3 bucket via the `dashboard_sync.yml` workflow.
 Benchmark metrics (`completed_commits.json` and the `results/` directory) are stored in the same bucket so the dashboard can fetch them directly.
 
-## Custom base path
-
-If the metrics are stored under a prefix other than the bucket root, pass a `base` query parameter when loading `index.html`:
-
-```
-https://<bucket-url>/dashboard/index.html?base=path/to/prefix
-```
-
-The dashboard will prepend this prefix when requesting `completed_commits.json` and per-commit metrics files.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,16 @@
+# Dashboard
+
+This folder contains a lightweight React-based dashboard used to visualize benchmark results.
+
+The static files are uploaded to an Amazon S3 bucket via the `dashboard_sync.yml` workflow.
+Benchmark metrics (`completed_commits.json` and the `results/` directory) are stored in the same bucket so the dashboard can fetch them directly.
+
+## Custom base path
+
+If the metrics are stored under a prefix other than the bucket root, pass a `base` query parameter when loading `index.html`:
+
+```
+https://<bucket-url>/dashboard/index.html?base=path/to/prefix
+```
+
+The dashboard will prepend this prefix when requesting `completed_commits.json` and per-commit metrics files.

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -8,11 +8,8 @@
 
 /* global React, ReactDOM, Recharts */
 
-const queryParams = new URLSearchParams(window.location.search);
-const rawBase = queryParams.get('base');
-const BASE = rawBase ? `../${rawBase.replace(/\/+$/, '')}` : '..';
-const COMPLETED_URL = `${BASE}/completed_commits.json`;
-const RESULT_URL = sha => `${BASE}/results/${sha}/metrics.json`;
+const COMPLETED_URL = "../completed_commits.json";
+const RESULT_URL = sha => `../results/${sha}/metrics.json`;
 
 const {
   ResponsiveContainer,

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -8,8 +8,11 @@
 
 /* global React, ReactDOM, Recharts */
 
-const COMPLETED_URL = "../completed_commits.json";
-const RESULT_URL = sha => `../results/${sha}/metrics.json`;
+const queryParams = new URLSearchParams(window.location.search);
+const rawBase = queryParams.get('base');
+const BASE = rawBase ? `../${rawBase.replace(/\/+$/, '')}` : '..';
+const COMPLETED_URL = `${BASE}/completed_commits.json`;
+const RESULT_URL = sha => `${BASE}/results/${sha}/metrics.json`;
 
 const {
   ResponsiveContainer,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <title>Valkey Continuous Benchmark</title>
 
+  <!-- Pass ?base=PREFIX to load metrics from a subdirectory -->
+
   <!-- Tailwind for quick styling -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/tailwindcss@3/dist/tailwind.min.css"/>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <title>Valkey Continuous Benchmark</title>
 
-  <!-- Pass ?base=PREFIX to load metrics from a subdirectory -->
 
   <!-- Tailwind for quick styling -->
   <link rel="stylesheet"


### PR DESCRIPTION
## Summary
- document dashboard hosting on S3
- allow dashboard JS to specify a custom metrics prefix via `?base=`
- add README for `dashboard/`
- note query parameter in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68474b936f6083218e1ffd2725118c7b