### PR TITLE
Fix command filter reset in dashboard

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -125,9 +125,15 @@ function Dashboard() {
     [metrics]
   );
 
-  // when command list changes, select all by default
+  // when command list changes, keep user selections but
+  // automatically include any new commands that appear
   React.useEffect(() => {
-    setSelectedCommands(new Set(commands));
+    setSelectedCommands(prev => {
+      if (!prev.size) return new Set(commands);
+      const next = new Set([...prev].filter(c => commands.includes(c)));
+      commands.forEach(c => { if (!prev.has(c)) next.add(c); });
+      return next;
+    });
   }, [commands]);
 
   // regroup per command → series of commit metrics


### PR DESCRIPTION
## Summary
- keep checkbox selections when metrics refresh

## Testing
- `node --check dashboard/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68478646b2f88321b6f1317bfe6a76cd