### PR TITLE
Add benchmark status tracking

### DIFF
--- a/.github/workflows/valkey_benchmark.yml
+++ b/.github/workflows/valkey_benchmark.yml
@@ -82,6 +82,21 @@ jobs:
               [[ ${#to_benchmark[@]} -ge $MAX_COMMITS ]] && break
             done
             echo "commit_ids=${to_benchmark[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Mark commits as in progress
+        working-directory: valkey
+        run: |
+          cp completed_commits.json temp.json 2>/dev/null || echo '[]' > temp.json
+          for sha in ${{ steps.determine_commits.outputs.commit_ids }}; do
+            ts=$(git show -s --format=%cI "$sha")
+            if jq -e '.[] | select(.sha=="'$sha'")' temp.json > /dev/null; then
+              jq 'map(if .sha=="'$sha'" then .status="in_progress" else . end)' temp.json > updated.json && mv updated.json temp.json
+            else
+              jq ". + [{\"sha\":\"$sha\",\"timestamp\":\"$ts\",\"status\":\"in_progress\"}]" temp.json > updated.json && mv updated.json temp.json
+            fi
+          done
+          mv temp.json completed_commits.json
+          aws s3 cp completed_commits.json "s3://${{ secrets.AWS_S3_BUCKET }}/completed_commits.json"
   
       - name: benchmark_commits
         working-directory: valkey-perf-benchmark
@@ -113,18 +128,13 @@ jobs:
       - name: Update completed_commits.json
         working-directory: valkey
         run: |
-          # Read existing completed commits
-          if [[ -f completed_commits.json ]]; then
-            jq '.' completed_commits.json > temp.json
-          else
-            echo '[]' > temp.json
-          fi
-
-          # Add new commits with timestamp
+          cp completed_commits.json temp.json 2>/dev/null || echo '[]' > temp.json
           for sha in ${{ steps.determine_commits.outputs.commit_ids }}; do
-            if ! jq -e '.[] | select(.sha=="'"$sha"'")' temp.json > /dev/null; then
-              ts=$(git show -s --format=%cI "$sha")
-              jq ". + [{\"sha\":\"$sha\",\"timestamp\":\"$ts\"}]" temp.json > updated.json && mv updated.json temp.json
+            ts=$(git show -s --format=%cI "$sha")
+            if jq -e '.[] | select(.sha=="'$sha'")' temp.json > /dev/null; then
+              jq 'map(if .sha=="'$sha'" then .status="complete" else . end)' temp.json > updated.json && mv updated.json temp.json
+            else
+              jq ". + [{\"sha\":\"$sha\",\"timestamp\":\"$ts\",\"status\":\"complete\"}]" temp.json > updated.json && mv updated.json temp.json
             fi
           done
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ benchmark metrics. Changes to this directory trigger the `dashboard_sync.yml`
 workflow which uploads the files to an Amazon S3 bucket configured for static
 website hosting. Metrics files (`completed_commits.json` and the `results/`
 folder) are stored in the same bucket so the dashboard can fetch them directly.
-`completed_commits.json` now stores objects containing the commit SHA and the
-original commit timestamp:
+`completed_commits.json` now stores objects containing the commit SHA, the
+original commit timestamp, and the benchmark status:
 
 ```json
-[ { "sha": "abcdef123", "timestamp": "2024-01-02T15:04:05Z" } ]
+[ { "sha": "abcdef123", "timestamp": "2024-01-02T15:04:05Z", "status": "complete" } ]
 ```
 
 Open `dashboard/index.html` from your bucket to view the latest benchmark

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -4,5 +4,5 @@ This folder contains a lightweight React-based dashboard used to visualize bench
 
 The static files are uploaded to an Amazon S3 bucket via the `dashboard_sync.yml` workflow.
 Benchmark metrics (`completed_commits.json` and the `results/` directory) are stored in the same bucket so the dashboard can fetch them directly. Each entry in
-`completed_commits.json` includes the commit SHA and its original timestamp.
+`completed_commits.json` includes the commit SHA, its original timestamp, and the benchmarking status.
 

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,6 +1,6 @@
 /* app.js — Valkey benchmark dashboard for last 100 commits
    Features:
-   • Fetch last 100 commit SHAs from completed_commits.json
+   • Fetch last 100 commit SHAs from completed_commits.json (including status)
    • Load metrics.json for each commit in parallel
    • Filter by cluster_mode and tls
    • Display separate trend charts for each command over the last commits


### PR DESCRIPTION
## Summary
- track commit benchmarking state in completed_commits.json
- document new `status` field in README and dashboard docs
- mention status tracking in dashboard code comments

## Testing
- `python -m py_compile benchmark.py valkey_benchmark.py valkey_build.py valkey_server.py logger.py process_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_684869704dd08321970a171f7698f366