### PR TITLE
Filter in-progress entries from dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ workflow which uploads the files to an Amazon S3 bucket configured for static
 website hosting. Metrics files (`completed_commits.json` and the `results/`
 folder) are stored in the same bucket so the dashboard can fetch them directly.
 `completed_commits.json` now stores objects containing the commit SHA, the
-original commit timestamp, and the benchmark status:
+original commit timestamp, and the benchmark status. The dashboard ignores
+entries with the status `in_progress`:
 
 ```json
 [ { "sha": "abcdef123", "timestamp": "2024-01-02T15:04:05Z", "status": "complete" } ]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -4,5 +4,5 @@ This folder contains a lightweight React-based dashboard used to visualize bench
 
 The static files are uploaded to an Amazon S3 bucket via the `dashboard_sync.yml` workflow.
 Benchmark metrics (`completed_commits.json` and the `results/` directory) are stored in the same bucket so the dashboard can fetch them directly. Each entry in
-`completed_commits.json` includes the commit SHA, its original timestamp, and the benchmarking status.
+`completed_commits.json` includes the commit SHA, its original timestamp, and the benchmarking status. Entries with `status: in_progress` are ignored by the dashboard.
 

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,6 +1,7 @@
 /* app.js — Valkey benchmark dashboard for all recorded commits
    Features:
-   • Fetch commit SHAs from completed_commits.json (including status)
+   • Fetch commit SHAs from completed_commits.json
+     (ignoring entries with status "in_progress")
    • Load metrics.json for each commit in parallel
    • Filter by cluster_mode and tls
    • Display separate trend charts for each command over the available commits
@@ -66,6 +67,7 @@ function Dashboard() {
         const list = [];
         const times = {};
         raw.forEach(c => {
+          if (typeof c === 'object' && c.status === 'in_progress') return;
           const sha = typeof c === 'string'
             ? c
             : (c.sha || c.commit || c.full);


### PR DESCRIPTION
## Summary
- skip in_progress records when loading `completed_commits.json`
- document that the dashboard ignores in-progress commits

## Testing
- `python -m py_compile benchmark.py valkey_server.py valkey_benchmark.py valkey_build.py process_metrics.py utils/*py`
- `node --check dashboard/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68491942a0988321b6d6751933120181