### PR TITLE
Fix dashboard longer date selection bug

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -160,6 +160,12 @@ function Dashboard() {
     [commits, commitTimes, fromDate, toDate]
   );
 
+  // reset brush range whenever the user changes the date filters so the
+  // full range of the new selection is displayed
+  React.useEffect(() => {
+    setBrushRange(null);
+  }, [fromDate, toDate]);
+
   React.useEffect(() => {
     if (!filteredCommits.length) {
       setBrushRange(null);


### PR DESCRIPTION
## Summary
- reset chart brush when date range changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check dashboard/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6849232f4c8083219b7fcee25833594b