### PR TITLE
Fix config parsing bug

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -123,7 +123,9 @@ def run_benchmark_matrix(*, commit_id: str, cfg: dict, args: argparse.Namespace)
     logging.getLogger().setLevel(args.log_level)
 
     builder = ServerBuilder(
-        commit_id=commit_id, tls_mode=cfg.tls_mode, valkey_path=args.valkey_path
+        commit_id=commit_id,
+        tls_mode=cfg["tls_mode"],
+        valkey_path=args.valkey_path,
     )
     if not args.use_running_server:
         builder.build()
@@ -132,8 +134,8 @@ def run_benchmark_matrix(*, commit_id: str, cfg: dict, args: argparse.Namespace)
 
     Logger.info(
         f"Commit {commit_id[:10]} | "
-        f"TLS={'on' if cfg.tls_mode == 'yes' else 'off'} | "
-        f"Cluster={'on' if cfg.cluster_mode == 'yes' else 'off'}"
+        f"TLS={'on' if cfg['tls_mode'] == 'yes' else 'off'} | "
+        f"Cluster={'on' if cfg['cluster_mode'] == 'yes' else 'off'}"
     )
     # ---- server side -----------------
     if (not args.use_running_server) and args.mode in ("server", "both"):
@@ -141,16 +143,16 @@ def run_benchmark_matrix(*, commit_id: str, cfg: dict, args: argparse.Namespace)
             commit_id=commit_id, valkey_path=args.valkey_path
         )
         launcher.launch_all_servers(
-            cluster_mode=cfg.cluster_mode,
-            tls_mode=cfg.tls_mode,
+            cluster_mode=cfg["cluster_mode"],
+            tls_mode=cfg["tls_mode"],
         )
 
     if args.mode in ("client", "both"):
         runner = ClientRunner(
             commit_id=commit_id,
             config=cfg,
-            cluster_mode=cfg.cluster_mode,
-            tls_mode=cfg.tls_mode,
+            cluster_mode=cfg["cluster_mode"],
+            tls_mode=cfg["tls_mode"],
             target_ip=args.target_ip,
             results_dir=results_dir,
             valkey_path=args.valkey_path,


### PR DESCRIPTION
## Summary
- fix benchmark config usage by treating it as a dict

## Testing
- `python -m py_compile benchmark.py valkey_benchmark.py valkey_build.py valkey_server.py process_metrics.py logger.py`
- `python benchmark.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6850ced3fb188321bf498ff7a95d2767