### PR TITLE
Cleanup and format Python modules

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -116,7 +116,9 @@ def ensure_results_dir(root: Path, commit_id: str) -> Path:
     return d
 
 
-def run_benchmark_matrix(*, commit_id: str, cfg: dict, args: argparse.Namespace) -> None:
+def run_benchmark_matrix(
+    *, commit_id: str, cfg: dict, args: argparse.Namespace
+) -> None:
     """Run benchmarks for all tls and cluster mode combinations."""
     results_dir = ensure_results_dir(args.results_dir, commit_id)
     Logger.init_logging(results_dir / "logs.txt")
@@ -139,9 +141,7 @@ def run_benchmark_matrix(*, commit_id: str, cfg: dict, args: argparse.Namespace)
     )
     # ---- server side -----------------
     if (not args.use_running_server) and args.mode in ("server", "both"):
-        launcher = ServerLauncher(
-            commit_id=commit_id, valkey_path=args.valkey_path
-        )
+        launcher = ServerLauncher(commit_id=commit_id, valkey_path=args.valkey_path)
         launcher.launch_all_servers(
             cluster_mode=cfg["cluster_mode"],
             tls_mode=cfg["tls_mode"],
@@ -163,6 +163,7 @@ def run_benchmark_matrix(*, commit_id: str, cfg: dict, args: argparse.Namespace)
         if not args.use_running_server:
             runner.cleanup_terminate()
 
+
 # ---------- Entry point ------------------------------------------------------
 def main() -> None:
     """Entry point for the benchmark CLI."""
@@ -173,7 +174,6 @@ def main() -> None:
             "ERROR: --use-running-server implies the valkey is already build and running, "
             "so --mode must be 'client'."
         )
-    print(args)
 
     commits = args.commits.copy()
     if args.baseline and args.baseline not in commits:
@@ -184,6 +184,6 @@ def main() -> None:
         for commit in commits:
             run_benchmark_matrix(commit_id=commit, cfg=cfg, args=args)
 
+
 if __name__ == "__main__":
     main()
-

--- a/logger.py
+++ b/logger.py
@@ -68,6 +68,6 @@ class Logger:
         def write(self, message: str) -> None:
             if message.strip():
                 self.logger.log(self.level, message.strip())
+
         def flush(self) -> None:
             pass
-

--- a/process_metrics.py
+++ b/process_metrics.py
@@ -23,7 +23,9 @@ class MetricsProcessor:
         ISO8601 commit timestamp.
     """
 
-    def __init__(self, commit_id: str, cluster_mode: bool, tls_mode: bool, commit_time: str) -> None:
+    def __init__(
+        self, commit_id: str, cluster_mode: bool, tls_mode: bool, commit_time: str
+    ) -> None:
         self.commit_id = commit_id
         self.cluster_mode = cluster_mode
         self.tls_mode = tls_mode
@@ -64,7 +66,9 @@ class MetricsProcessor:
             "tls": self.tls_mode,
         }
 
-    def write_metrics(self, results_dir: Path, new_metrics: List[Dict[str, object]]) -> None:
+    def write_metrics(
+        self, results_dir: Path, new_metrics: List[Dict[str, object]]
+    ) -> None:
         """Append metrics to ``results_dir/metrics.json``."""
         metrics_file = results_dir / "metrics.json"
         metrics = []
@@ -85,4 +89,3 @@ class MetricsProcessor:
             json.dump(metrics, f, indent=4)
 
         Logger.info(f"Metrics written to {metrics_file}")
-

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -5,7 +5,9 @@ import sys
 
 
 if len(sys.argv) < 3:
-    print("Usage: compare_benchmark_results.py BASELINE NEW [OUT_FILE]", file=sys.stderr)
+    print(
+        "Usage: compare_benchmark_results.py BASELINE NEW [OUT_FILE]", file=sys.stderr
+    )
     sys.exit(1)
 
 baseline_file = sys.argv[1]
@@ -38,10 +40,18 @@ def summarize(data_item):
     """Summarize a single benchmark result item."""
     return {
         "rps": data_item.get("rps", 0.0),
-        "latency_avg_ms": data_item.get("avg_latency_ms", data_item.get("latency_avg_ms", 0.0)),
-        "latency_p50_ms": data_item.get("p50_latency_ms", data_item.get("latency_p50_ms", 0.0)),
-        "latency_p95_ms": data_item.get("p95_latency_ms", data_item.get("latency_p95_ms", 0.0)),
-        "latency_p99_ms": data_item.get("p99_latency_ms", data_item.get("latency_p99_ms", 0.0)),
+        "latency_avg_ms": data_item.get(
+            "avg_latency_ms", data_item.get("latency_avg_ms", 0.0)
+        ),
+        "latency_p50_ms": data_item.get(
+            "p50_latency_ms", data_item.get("latency_p50_ms", 0.0)
+        ),
+        "latency_p95_ms": data_item.get(
+            "p95_latency_ms", data_item.get("latency_p95_ms", 0.0)
+        ),
+        "latency_p99_ms": data_item.get(
+            "p99_latency_ms", data_item.get("latency_p99_ms", 0.0)
+        ),
     }
 
 
@@ -58,7 +68,9 @@ baseline_by_command = group_by_command(baseline_data)
 new_by_command = group_by_command(new_data)
 
 # Get all unique commands
-all_commands = sorted(set(list(baseline_by_command.keys()) + list(new_by_command.keys())))
+all_commands = sorted(
+    set(list(baseline_by_command.keys()) + list(new_by_command.keys()))
+)
 
 metrics = [
     "rps",
@@ -75,29 +87,31 @@ for command in all_commands:
     lines.append(f"## {command}\n")
     lines.append("| Metric | Baseline | PR | Diff | % Change |")
     lines.append("| --- | --- | --- | --- | --- |")
-    
+
     # Get data for this command
     baseline_items = baseline_by_command.get(command, [])
     new_items = new_by_command.get(command, [])
-    
+
     # If we have multiple items for the same command, use the first one
     baseline_item = baseline_items[0] if baseline_items else {}
     new_item = new_items[0] if new_items else {}
-    
+
     # Summarize
     baseline_summary = summarize(baseline_item)
     new_summary = summarize(new_item)
-    
+
     # Generate metrics rows
     for metric in metrics:
         baseline_value = baseline_summary.get(metric, 0.0)
         new_value = new_summary.get(metric, 0.0)
         diff = new_value - baseline_value
         change = pct_change(new_value, baseline_value)
-        
+
         # Format the row with appropriate precision
-        lines.append(f"| {metric} | {baseline_value:.2f} | {new_value:.2f} | {diff:.2f} | {change:+.2f}% |")
-    
+        lines.append(
+            f"| {metric} | {baseline_value:.2f} | {new_value:.2f} | {diff:.2f} | {change:+.2f}% |"
+        )
+
     lines.append("")  # Add empty line between command sections
 
 # Join all lines

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -38,7 +38,7 @@ class ClientRunner:
         self.valkey_path = valkey_path
         self.valkey_cli = f"{valkey_path}/{VALKEY_CLI}"
         self.valkey_benchmark = f"{valkey_path}/{VALKEY_BENCHMARK}"
-    
+
     def _run(self, cmd: Iterable[str]) -> None:
         """Execute a command and log failures."""
 
@@ -256,7 +256,7 @@ class ClientRunner:
                 "./tests/tls/ca.crt",
             ]
         return cmd
-    
+
     def cleanup_terminate(self) -> None:
         """Cleanup any resources or processes."""
         Logger.info("Cleaning up resources...")
@@ -264,4 +264,3 @@ class ClientRunner:
         self._run(cleanup_cmd)
         terminiate_cmd = ["pkill", "-f", "valkey-server"]
         self._run(terminiate_cmd)
-        pass

--- a/valkey_build.py
+++ b/valkey_build.py
@@ -50,4 +50,3 @@ class ServerBuilder:
             self._run("./utils/gen-test-certs.sh", cwd=self.valkey_dir)
         else:
             self._run(["make", "-j"], cwd=self.valkey_dir)
-

--- a/valkey_server.py
+++ b/valkey_server.py
@@ -119,4 +119,3 @@ class ServerLauncher:
         time.sleep(2)
         self._run(add_slots_cmd)
         time.sleep(2)
-


### PR DESCRIPTION
## Summary
- run `black` on all scripts
- remove leftover debug print in `benchmark.py`
- delete extraneous `pass` in `ClientRunner.cleanup_terminate`

## Testing
- `python3 -m py_compile benchmark.py valkey_benchmark.py valkey_server.py valkey_build.py process_metrics.py logger.py utils/compare_benchmark_results.py`

------
https://chatgpt.com/codex/tasks/task_e_68525ef2ef408321b072faf6f0302f2d